### PR TITLE
Add nonprofit disclaimer and mission statement to footer

### DIFF
--- a/css/site-1.css
+++ b/css/site-1.css
@@ -179,6 +179,11 @@ section#location address {font-size:1.5rem;}
 footer {padding:20px 0 10px;}
 footer p.copyright {}
 footer ul.list-inline li {text-transform:uppercase; font-size: 12px;}
+footer .footer-legal-row {margin-top:20px; padding-top:20px; border-top:1px solid #e6e6e6;}
+footer .footer-mission {margin-bottom:5px; font-weight:500;}
+footer .footer-legal {font-size:12px; color:#6c757d; margin-bottom:0;}
+footer ul.social-buttons {margin-bottom:0;}
+footer .row {align-items:center;}
 
 /* ========== Social Icons ========== */
 ul.social-buttons {margin-bottom: 40px;}

--- a/index.html
+++ b/index.html
@@ -622,6 +622,12 @@
         <!-- /.Footer Social Profiles List -->
       </div>
     </div>
+    <div class="row footer-legal-row">
+      <div class="col-12">
+        <p class="footer-mission">CommunityKit runs free educational events to promote learning and access to software development.</p>
+        <p class="footer-legal">CommunityKit is a nonprofit, tax-exempt charitable organization (tax ID number 41-5047736) under Section 501(c)(3) of the Internal Revenue Code. Donations are tax-deductible as allowed by law. CommunityKit is registered as Michigan charitable trust #70898.</p>
+      </div>
+    </div>
   </div>
 </footer>
 

--- a/schedule/index.html
+++ b/schedule/index.html
@@ -909,6 +909,12 @@ body.schedule-page {
         </ul>
       </div>
     </div>
+    <div class="row footer-legal-row">
+      <div class="col-12">
+        <p class="footer-mission">CommunityKit runs free educational events to promote learning and access to software development.</p>
+        <p class="footer-legal">CommunityKit is a nonprofit, tax-exempt charitable organization (tax ID number 41-5047736) under Section 501(c)(3) of the Internal Revenue Code. Donations are tax-deductible as allowed by law. CommunityKit is registered as Michigan charitable trust #70898.</p>
+      </div>
+    </div>
   </div>
 </footer>
 


### PR DESCRIPTION
## Summary
Adds the required legal disclaimer and mission statement to the site footer.

- **Mission statement:** "CommunityKit runs free educational events to promote learning and access to software development."
- **Legal disclaimer:** 501(c)(3) tax-exempt status, tax ID, and Michigan charitable trust registration.

Both appear in a new divider-separated row beneath the existing copyright/social row, on the home page (`index.html`) and the schedule page (`schedule/index.html`). The code-of-conduct page footer was intentionally left unchanged.

## Changes
- `index.html`, `schedule/index.html` — new `footer-legal-row` with mission + legal text.
- `css/site-1.css` — styling for the new row (subtle top divider, muted legal text) and a footer-scoped fix to remove the social-icon trailing margin that was causing an awkward gap.

## Testing
Verified locally at desktop (1280px) and mobile (390px) widths on both pages.